### PR TITLE
Inline internals, landing leg

### DIFF
--- a/GameData/KerbalHistoricalInstitute/IWNO/Parts/Command/mk1InlineCockpit/part.cfg
+++ b/GameData/KerbalHistoricalInstitute/IWNO/Parts/Command/mk1InlineCockpit/part.cfg
@@ -51,7 +51,8 @@ CrewCapacity = 1
 bulkheadProfiles = size1, srf
 INTERNAL
 {
-  name = MK1_Inline_Int
+  //name = MK1_Inline_Int //The MK1_Inline_Int interior is missing. STH 2018-0603
+  name = mk1InlineInternal
 }
 
 MODULE

--- a/GameData/KerbalHistoricalInstitute/IWNO/Parts/Command/mk1InlineCockpit2/mk1InlineCockpit.cfg
+++ b/GameData/KerbalHistoricalInstitute/IWNO/Parts/Command/mk1InlineCockpit2/mk1InlineCockpit.cfg
@@ -29,7 +29,8 @@ PART
 	bulkheadProfiles = size1, srf
 	INTERNAL
 	{
-		name =  MK1_Inline_Int
+		//name = MK1_Inline_Int //The MK1_Inline_Int interior is missing. STH 2018-0603
+		name = mk1InlineInternal
 	}
 	MODULE
 	{

--- a/GameData/KerbalHistoricalInstitute/Kerbal Historical Institute/Parts/Ground/LandingLegLT-1/part.cfg
+++ b/GameData/KerbalHistoricalInstitute/Kerbal Historical Institute/Parts/Ground/LandingLegLT-1/part.cfg
@@ -48,6 +48,7 @@ PART{
     startEventGUIName = #autoLOC_6001338 //#autoLOC_6001338 = Extend
     endEventGUIName = #autoLOC_6001339 //#autoLOC_6001339 = Retract
     actionGUIName = #autoLOC_6001337 //#autoLOC_6001337 = Toggle Deploy
+    defaultActionGroup = Gear
     allowDeployLimit = true
     revClampDirection = false
     revClampSpeed = true

--- a/GameData/KerbalHistoricalInstitute/Kerbal Historical Institute/Parts/Ground/SmallGearBay/smallGearBay.cfg
+++ b/GameData/KerbalHistoricalInstitute/Kerbal Historical Institute/Parts/Ground/SmallGearBay/smallGearBay.cfg
@@ -7,9 +7,11 @@ PART
 	scale = 1.0
 	node_attach = 0.00, 0.147, 0.00, 0.0, 1.0, 0.0, 1
 	TechRequired = landing
+	TechHidden = True
 	entryCost = 3200
 	cost = 450
-	category = Ground
+	//category = Ground
+	category = none
 	subcategory = 0
 	title = #autoLOC_500984 //#autoLOC_500984 = LY-10 Small Landing Gear
 	manufacturer = #autoLOC_501653 //#autoLOC_501653 = LightYear Tire Company


### PR DESCRIPTION
Inline cockpits now have internals. This lets players move kerbals in/out of the parts and gives them a crew image in the lower right of play screen.

The landing leg should now automatically work with the "gear" action group.